### PR TITLE
Refatoração: Implementação do Mapper e DTO para Missões

### DIFF
--- a/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesController.java
+++ b/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesController.java
@@ -16,23 +16,23 @@ public class MissoesController {
     }
 
     @GetMapping("/listar")
-    public List<MissoesModel> listarMissoes(){
+    public List<MissoesDTO> listarMissoes(){
         return missoesService.listarMissoes();
     }
 
     @GetMapping("/listar/{id}")
-    public Optional<MissoesModel> listarMissao(@PathVariable Long id){
-        return missoesService.listarMissaoPorId(id);
+    public Optional<MissoesDTO> listarMissao(@PathVariable Long id){
+        return Optional.ofNullable(missoesService.listarMissaoPorId(id));
     }
 
     @PostMapping("/criar")
-    public MissoesModel criarMissao(@RequestBody MissoesModel missao) {
+    public MissoesDTO criarMissao(@RequestBody MissoesDTO missao) {
         return missoesService.criarMissao(missao);
     }
 
-    @PutMapping("/alterar")
-    public  String alterarMissao(){
-        return "Missao alterada com sucesso";
+    @PutMapping("/alterar/{id}")
+    public MissoesDTO atualizarMissao(@PathVariable Long id, @RequestBody MissoesDTO missaoAtualizada){
+        return missoesService.atualizarMissao(id,missaoAtualizada);
     }
 
     @DeleteMapping("/deletar/{id}")

--- a/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesDTO.java
+++ b/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesDTO.java
@@ -1,0 +1,18 @@
+package com.kaiobrenner.CadastroDeNinjas.Missoes;
+
+import com.kaiobrenner.CadastroDeNinjas.Ninjas.NinjaModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MissoesDTO {
+
+    private Long id;
+    private String nome;
+    private String dificuldade;
+    private List<NinjaModel> ninjas;
+}

--- a/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesMapper.java
+++ b/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesMapper.java
@@ -1,0 +1,30 @@
+package com.kaiobrenner.CadastroDeNinjas.Missoes;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissoesMapper {
+
+    public MissoesModel map(MissoesDTO missoesDTO){
+        MissoesModel missoesModel = new MissoesModel();
+
+        missoesModel.setId(missoesDTO.getId());
+        missoesModel.setNome(missoesDTO.getNome());
+        missoesModel.setDificuldade(missoesDTO.getDificuldade());
+        missoesModel.setNinjas(missoesDTO.getNinjas());
+
+        return missoesModel;
+    }
+
+
+    public MissoesDTO map(MissoesModel missoesModel){
+        MissoesDTO missoesDTO = new MissoesDTO();
+
+        missoesDTO.setId(missoesModel.getId());
+        missoesDTO.setNome(missoesModel.getNome());
+        missoesDTO.setDificuldade(missoesModel.getDificuldade());
+        missoesDTO.setNinjas(missoesModel.getNinjas());
+
+        return missoesDTO;
+    }
+}

--- a/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesService.java
+++ b/src/main/java/com/kaiobrenner/CadastroDeNinjas/Missoes/MissoesService.java
@@ -3,28 +3,53 @@ package com.kaiobrenner.CadastroDeNinjas.Missoes;
 import com.kaiobrenner.CadastroDeNinjas.Ninjas.NinjaModel;
 import org.springframework.stereotype.Service;
 
+import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class MissoesService {
 
     private MissoesRepository missoesRepository;
+    private MissoesMapper missoesMapper;
 
-    public MissoesService(MissoesRepository missoesRepository) {
+    public MissoesService(MissoesRepository missoesRepository, MissoesMapper missoesMapper) {
         this.missoesRepository = missoesRepository;
+        this.missoesMapper = missoesMapper;
     }
 
-    public List<MissoesModel> listarMissoes(){
-        return missoesRepository.findAll();
+    public List<MissoesDTO> listarMissoes(){
+        List<MissoesModel> missoes = missoesRepository.findAll();
+        return missoes.stream()
+                .map(missoesMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public Optional<MissoesModel> listarMissaoPorId(Long id){
-        return missoesRepository.findById(id);
+    public MissoesDTO listarMissaoPorId(Long id){
+        Optional<MissoesModel> missaoPorId = missoesRepository.findById(id);
+        return missaoPorId.map(missoesMapper::map).orElse(null);
     }
 
-    public MissoesModel criarMissao(MissoesModel missao){
-        return missoesRepository.save(missao);
+    public MissoesDTO atualizarMissao(Long id, MissoesDTO missoesDTO){
+        Optional<MissoesModel> missaoExistente = missoesRepository.findById(id);
+
+        if(missaoExistente.isPresent()){
+            MissoesModel missaoAtualizada = missoesMapper.map(missoesDTO);
+            missaoAtualizada.setId(id);
+            MissoesModel missaoSalva = missoesRepository.save(missaoAtualizada);
+
+            return missoesMapper.map(missaoSalva);
+        }
+
+        return null;
+    }
+
+    public MissoesDTO criarMissao(MissoesDTO missaoDTO){
+        MissoesModel missao = missoesMapper.map(missaoDTO);
+        missao = missoesRepository.save(missao);
+
+        return missoesMapper.map(missao);
     }
 
     public void deletarMissaoPorId(Long id){

--- a/src/main/java/com/kaiobrenner/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/src/main/java/com/kaiobrenner/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -1,7 +1,6 @@
 package com.kaiobrenner.CadastroDeNinjas.Ninjas;
 
 import com.kaiobrenner.CadastroDeNinjas.Missoes.MissoesModel;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;


### PR DESCRIPTION
Alterações propostas pelo PR

Implementação do MissoesMapper para conversão entre MissoesModel e MissoesDTO.

Criação do MissoesDTO contendo os campos necessários para comunicação externa.

Refatoração do MissoesService para utilizar o MissoesDTO, eliminando a exposição direta do MissoesModel.

Ajustes no MissoesController para trabalhar com o MissoesDTO, garantindo uma estrutura mais coesa e desacoplada.

Essas mudanças visam melhorar a organização do código e a separação de responsabilidades, facilitando a manutenção e expansão futura da aplicação.